### PR TITLE
After task deployment_cache, env() function does not work in view

### DIFF
--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -1,5 +1,6 @@
+@include('vendor/autoload.php')
+
 @setup
-	require __DIR__.'/vendor/autoload.php';
 	$dotenv = Dotenv\Dotenv::create(__DIR__);
 	try {
 		$dotenv->load();

--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -102,6 +102,7 @@
 @task('deployment_cache')
 	php {{ $release }}/artisan view:clear --quiet
 	php {{ $release }}/artisan cache:clear --quiet
+	php {{ $release }}/artisan config:clear --quiet
 	php {{ $release }}/artisan config:cache --quiet
 	echo "Cache cleared"
 @endtask


### PR DESCRIPTION
Hi, 
After clear cache and cache config, env() function does not work in blade view.
I believe this is the same issue with the below link.
https://stackoverflow.com/questions/34420761/laravel-5-2-not-reading-env-file