### PR TITLE
Removed getenv feature (unsafe in Laravel 8 / dotenv 5.x)

### DIFF
--- a/Envoy.blade.php
+++ b/Envoy.blade.php
@@ -8,11 +8,11 @@
 		echo $e->getMessage();
 	}
 
-	$server = getenv('DEPLOY_SERVER');
-	$repo = getenv('DEPLOY_REPOSITORY');
-	$path = getenv('DEPLOY_PATH');
-	$slack = getenv('DEPLOY_SLACK_WEBHOOK');
-	$healthUrl = getenv('DEPLOY_HEALTH_CHECK');
+	$server = $_ENV['DEPLOY_SERVER'] ?? null;
+	$repo = $_ENV['DEPLOY_REPOSITORY'] ?? null;
+	$path = $_ENV['DEPLOY_PATH'] ?? null;
+	$slack = $_ENV['DEPLOY_SLACK_WEBHOOK'] ?? null;
+	$healthUrl = $_ENV['DEPLOY_HEALTH_CHECK'] ?? null;
 
 	if ( substr($path, 0, 1) !== '/' ) throw new Exception('Careful - your deployment path does not begin with /');
 

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
+        "php": "^7.0",
         "vlucas/phpdotenv": "^4.0"
     }
 }


### PR DESCRIPTION
`getenv` function is no longer safe in Laravel 7 / DotEnv 5.x - https://github.com/vlucas/phpdotenv#putenv-and-getenv.

Switched to using `$_ENV` with PHP >= 7  null coalesce operator.